### PR TITLE
Added darkTheme argument to twemoji-picker

### DIFF
--- a/src/components/TwemojiPicker/TwemojiPicker.vue
+++ b/src/components/TwemojiPicker/TwemojiPicker.vue
@@ -9,6 +9,7 @@
       :arrowEnabled="pickerArrowEnabled"
       :closeOnClickaway="pickerCloseOnClickaway"
       :extraPaddingOffset="pickerPaddingOffset"
+      :darkTheme="darkTheme"
       @popperOpenChanged="popperOpenChanged"
       ref="popupEmoji"
     >
@@ -16,9 +17,12 @@
         <div id="emoji-container">
           <div
             id="emoji-popup"
-            :style="{ width: calculatedPickerWidth + 'px' }"
+            :style="{
+              width: calculatedPickerWidth + 'px',
+              backgroundColor: pickerTheme,
+            }"
           >
-            <div id="emoji-popover-search" v-if="searchEmojisFeat">
+            <div id="emoji-popover-search" v-if="searchEmojisFeat" :style="{ backgroundColor: pickerTheme }">
               <div
                 id="search-header"
                 :class="{ 'is-focused': isSearchFocused }"
@@ -34,7 +38,7 @@
               </div>
             </div>
 
-            <div id="emoji-popover-header" class="scroll-min">
+            <div id="emoji-popover-header" class="scroll-min" :style="{ backgroundColor: pickerTheme }">
               <span
                 v-if="recentEmojisFeat && recentEmojis.length !== 0"
                 v-html="getEmojiImgFromUnicode('🕒')"
@@ -56,6 +60,7 @@
             <div
               class="emoji-popover-inner"
               :style="{
+                backgroundColor: pickerTheme,
                 width: calculatedPickerWidth + 'px',
                 height: pickerHeight + 'px',
               }"
@@ -201,7 +206,7 @@
     .emoji-popover-inner {
       overflow-y: auto;
       overflow-x: hidden;
-      background-color: #f7f7f7;
+      /**background-color: #f7f7f7; **/
 
       &::-webkit-scrollbar-track {
         border-radius: 10px;
@@ -244,7 +249,7 @@
     }
 
     #emoji-popover-search {
-      background-color: #f7f7f7;
+      /* background-color: #f7f7f7; */
       border-radius: 3px;
       margin: 5px 0;
 
@@ -408,6 +413,13 @@ export default Vue.extend({
   },
 
   computed: {
+    pickerTheme(): string {
+      if (this.darkTheme) {
+        return '#696761';
+      } else {
+        return '#f7f7f7';
+      }
+    },
     randomEmojiImg(): string {
       this.triggerShowEmoji();
       return EmojiService.getEmojiImgFromUnicode(

--- a/src/components/TwemojiPicker/props.ts
+++ b/src/components/TwemojiPicker/props.ts
@@ -216,4 +216,12 @@ export default {
     default: false,
     type: Boolean
   },
+  theme: {
+    default: '',
+    type: String,
+  },
+  darkTheme: {
+    default: false,
+    type: Boolean,
+  },
 }


### PR DESCRIPTION
It can be used with the "darkTheme" boolean argument in a <twemoji-picker/> widget.
When set as "true" dark theme will be enabled, dark theme is disabled by default

<img width="319" alt="image" src="https://user-images.githubusercontent.com/45199202/171177369-08c0a915-81fa-49b1-b807-ab4b2b67cff2.png">

Currently it is a work in progress since the scrollbars are not displayed as dark yet, and the search field is not fully dark when selected.

<img width="354" alt="image" src="https://user-images.githubusercontent.com/45199202/171177676-00e1571c-351a-41af-bdec-797ab2204271.png">

The dark mode palette is subject to change to something better looking
<img width="337" alt="image" src="https://user-images.githubusercontent.com/45199202/171178529-92b7dad5-e0bf-480f-8a05-41ff109b464e.png">
