### PR TITLE
Fix CDN error

### DIFF
--- a/docs/docs/twemoji-picker-api/index.md
+++ b/docs/docs/twemoji-picker-api/index.md
@@ -135,7 +135,7 @@ Defines the loading label.
 
 ### twemojiPath
 - Type: ``string``
-- Default: ``'https://cdnjs.cloudflare.com/ajax/libs/twemoji/'``
+- Default: ``'https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/'``
 
 Defines the CDN where the Twemoji official library will request the emoji arts.
 

--- a/docs/docs/twemoji-picker-api/index.md
+++ b/docs/docs/twemoji-picker-api/index.md
@@ -135,7 +135,7 @@ Defines the loading label.
 
 ### twemojiPath
 - Type: ``string``
-- Default: ``'https://twemoji.maxcdn.com/2/'``
+- Default: ``'https://cdnjs.cloudflare.com/ajax/libs/twemoji/'``
 
 Defines the CDN where the Twemoji official library will request the emoji arts.
 

--- a/src/components/TwemojiPicker/props.ts
+++ b/src/components/TwemojiPicker/props.ts
@@ -155,7 +155,7 @@ export default {
     type: String
   },
   twemojiPath: {
-    default: 'https://twemoji.maxcdn.com/2/',
+    default: 'https://cdnjs.cloudflare.com/ajax/libs/twemoji/',
     type: String
   },
   twemojiExtension: {

--- a/src/components/TwemojiPicker/props.ts
+++ b/src/components/TwemojiPicker/props.ts
@@ -155,7 +155,7 @@ export default {
     type: String
   },
   twemojiPath: {
-    default: 'https://cdnjs.cloudflare.com/ajax/libs/twemoji/',
+    default: 'https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/',
     type: String
   },
   twemojiExtension: {


### PR DESCRIPTION
### Description
Maxcdn has shut down, CDN not working anymore. - [Official issue](https://github.com/twitter/twemoji/issues/580)

For hotfix in projects use `twemojiPath` param:
```vue
<twemoji-picker
    ...
    twemojiPath="https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/"
>
```

### Changes
+ Updated default CDN path to `cloudflare`